### PR TITLE
python howto: properly namespace field function

### DIFF
--- a/docs/arcaflow/creating-plugins/python.md
+++ b/docs/arcaflow/creating-plugins/python.md
@@ -362,7 +362,7 @@ You can add metadata to your schema by using the `field()` parameter for datacla
 ```python
 @dataclasses.dataclass
 class MyClass:
-    param: str = field(metadata={"id": "my-param", "name":"Parameter 1", "description": "This is a parameter"})
+    param: str = dataclasses.field(metadata={"id": "my-param", "name":"Parameter 1", "description": "This is a parameter"})
 ```
 
 ## Creating your plugin the hard way


### PR DESCRIPTION
## Changes introduced with this PR

Properly namespace `field` function which belong to `dataclasses` module.
Without it the plugin will fail with `field` being undefined.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>