### PR TITLE
bump opensearch plugin version 0.1.0 > 0.1.1

### DIFF
--- a/docs/arcaflow/getting-started.md
+++ b/docs/arcaflow/getting-started.md
@@ -219,7 +219,7 @@ steps:
     plugin: quay.io/arcalot/arcaflow-plugin-metadata:0.1.0
     input: {}
   opensearch:
-    plugin: quay.io/arcalot/arcaflow-plugin-opensearch:0.1.0
+    plugin: quay.io/arcalot/arcaflow-plugin-opensearch:0.1.1
     input:
       url: !expr $.input.elastic_host
       username: !expr $.input.elastic_username


### PR DESCRIPTION
## Changes introduced with this PR

bump opensearch plugin version 0.1.0 > 0.1.1

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).