### PR TITLE
Syntax Highlight for Python Dockerfile in packaging.md

### DIFF
--- a/docs/arcaflow/plugins/packaging.md
+++ b/docs/arcaflow/plugins/packaging.md
@@ -10,7 +10,7 @@ Currently, we only support the manual method for non-Arcalot plugins. However, i
 
     With Python, the Dockerfile heavily depends on which build tool you are using. Here we are demonstrating the usage using pip.
     
-    ```
+    ```Dockerfile
     FROM python:alpine
 
     # Add the plugin contents


### PR DESCRIPTION
## Changes introduced with this PR

Some :lipstick: for a missing code block syntax highlight.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).