### PR TITLE
Add filenames to some code snippets

### DIFF
--- a/docs/arcaflow/getting-started.md
+++ b/docs/arcaflow/getting-started.md
@@ -81,7 +81,7 @@ CMD []
 
 Let's start with something simple: we'll incorporate the plugin above into a workflow. Let's create a `workflow.yaml` in an empty directory
 
-```yaml
+```yaml title="workflow.yaml"
 input:
   root: RootObject
   objects:
@@ -107,7 +107,7 @@ output:
 
 Now, let's create an input file for our workflow named `input.yaml`:
 
-```yaml
+```yaml title="input.yaml"
 name: Arca Lot
 ```
 


### PR DESCRIPTION
## Changes introduced with this PR

Put some title attributes to the code snippets in the arcaflow getting-started docs to make it more trivial for someone to quickly see which files the snippets correspond to (instead of human parsing the sentences that explain them).

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).