### PR TITLE
Updated ansible cons

### DIFF
--- a/docs/arcaflow/index.md
+++ b/docs/arcaflow/index.md
@@ -55,6 +55,7 @@ You need to pick the right tool for the job. Sometimes, you need something simpl
         - Alternatively, you can run it from inside a container or python virtualenv
     - Depending on the module used, there may be system requirements for python or other dependencies on the target host/container.
         -  See [ansible documentation](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-handle-not-having-a-python-interpreter-at-usr-bin-python-on-a-remote-machine)
+    - Does not provide a consistent experience across baremetal and kubernetes environments (benchmarking may involve the use of different plugins to cover each scenario)
 
 ??? "Apache Airflow"
 


### PR DESCRIPTION
## Changes introduced with this PR

I think the fact that arcaflow provides a consistent experience across baremetal and kubernetes environments should be highlighted.

Trying to run some stress-ng workflow both on baremetal and k8s ends up with totally different Ansible plugins/implementation:
 - For baremetal:
```
 - name: Playbook for CI testing.
   hosts: localhost
   vars:
       - stress_ng_duration: "5"
       - fio_test_duration: "1"
       - skip_screen_check: True

   roles:
       - ansible-role-stress
```
 - For k8s:
```
 - hosts: localhost
  collections:
    - kubernetes.core
  tasks:
  - name: Create a stressng pod
    k8s:
      state: present
      definition:
        apiVersion: v1
        kind: Pod
        metadata:
          name: "stressng-1"
          namespace: default
        spec:
          containers:
          - name: stressng
            image: quay.io/cloud-bulldozer/stressng
            Command: “stress-ng -d 5 -f 1”
```



---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).