### PR TITLE
Fix workflow to use organization-selected versions of Go & Python

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,8 @@
 name: Build & Deploy Website
 on:
   push:
-    branches-ignore:
-      - 'gh-pages'
+    branches:
+      - 'main'
   pull_request:
     branches-ignore:
       - 'gh-pages'
@@ -15,10 +15,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
+        with:
+          go-version: ${{ vars.ARCALOT_GO_VERSION }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: ${{ vars.ARCALOT_PYTHON_VERSION }}
           architecture: x64
       - name: Install requirements.txt
         run: pip install -r requirements.txt
@@ -27,8 +29,7 @@ jobs:
           cd docsgen
           go build -o ../arcaflow-docsgen .
           chmod +x ../arcaflow-docsgen
-          cd ..
-          cd docs/arcaflow
+          cd ../docs/arcaflow
           ../../arcaflow-docsgen
       - name: Build site
         run: mkdocs build


### PR DESCRIPTION
## Changes introduced with this PR

This PR tweaks the workflow in a few ways:
- Rework the triggers to avoid running the CI twice on PRs:  currently it runs for pushes to upstream branches (other than `gh-pages`) and for PRs (other than ones for the `gh-pages` branch, although I doubt anyone ever submits PRs for that branch...), so a PR for an upstream branch would trigger two runs -- one for the PR and one for the update to the branch; with this change, the PR behavior is the same, but the CI will run only for pushes to the `main` branch.
- The versions of Go and Python used are selected via the `ARCALOT_GO_VERSION` and `ARCALOT_PYTHON_VERSION` GitHub organization-context variables, instead of defaulting to the runner's existing, installed versions.
- I combined two adjacent `cd` commands into one.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).